### PR TITLE
Support for Keyword insertion in ad head and description lines.

### DIFF
--- a/py/.dockerignore
+++ b/py/.dockerignore
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/Dockerfile
+++ b/py/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/common/__init__.py
+++ b/py/common/__init__.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/common/api_utils.py
+++ b/py/common/api_utils.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/common/api_utils_test.py
+++ b/py/common/api_utils_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/common/cloud_translation_client.py
+++ b/py/common/cloud_translation_client.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/common/cloud_translation_client.py
+++ b/py/common/cloud_translation_client.py
@@ -66,6 +66,11 @@ _GLOSSARY_FILE_VALIDATION_REGEX = r'^[a-z]{2}-to-[a-z]{2}-.+\.csv$'
 # being represented by multiple code points.
 _DEFAULT_BATCH_CHAR_LIMIT = 1500
 
+# Modified version of keyword insertion tag where the key is an alpha numeric
+# character instead of a key labeled "Keyword", etc. E.g, Buy {0:now}.
+# See py/data_models/ads.py
+_MODIFIED_KEYWORD_INSERTION_TAG_REGEX = re.compile(r'{\d:.+?}')
+
 
 @dataclasses.dataclass
 class Glossary:
@@ -351,14 +356,28 @@ class CloudTranslationClient:
       A DataFrame
     """
     # Gets the length of translations.
-    translation_lengths = [
-        len(target_term[target_language_code])
-        for target_term in translation_frame.df()[
-            translation_frame_lib.TARGET_TERMS
-        ]
-    ]
+    translation_lengths = []
+    for target_term in translation_frame.df()[
+        translation_frame_lib.TARGET_TERMS
+    ]:
+      # Only append target term lengths to list when the dataframe does not have
+      # an ads column and its text does not include keyword insertion tags
+      # because the text shortener may remove the tags. For example, "Data
+      # centers in {0:denver}" may resolve to "Denver data centers".
+      # TODO(): Shorten text that include keyword insertion tags for
+      # ads translations.
+      # TODO(): Add column/row for keyword insertion tags to ads
+      # dataframe.
+      if not _MODIFIED_KEYWORD_INSERTION_TAG_REGEX.search(
+          target_term[target_language_code]
+      ):
+        translation_lengths.append(len(target_term[target_language_code]))
+      else:
+        translation_lengths.append(0)
 
     # Gets translations that are > the char limit.
+    # TODO(): Change how translation lengths and character limits
+    # logic omits text with keyword insertion tags.
     return translation_frame.df()[
         translation_lengths
         > translation_frame.df()[translation_frame_lib.CHAR_LIMIT]

--- a/py/common/cloud_translation_client_test.py
+++ b/py/common/cloud_translation_client_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/common/execution_analytics_client.py
+++ b/py/common/execution_analytics_client.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/common/execution_analytics_client_test.py
+++ b/py/common/execution_analytics_client_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/common/gcloud_client.py
+++ b/py/common/gcloud_client.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/common/gcloud_client_test.py
+++ b/py/common/gcloud_client_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/common/google_ads_client.py
+++ b/py/common/google_ads_client.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/common/google_ads_client_test.py
+++ b/py/common/google_ads_client_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/common/palm_client.py
+++ b/py/common/palm_client.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/common/palm_client_test.py
+++ b/py/common/palm_client_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/common/storage_client.py
+++ b/py/common/storage_client.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/common/storage_client_test.py
+++ b/py/common/storage_client_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/common/utils.py
+++ b/py/common/utils.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/common/utils_test.py
+++ b/py/common/utils_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/common/vertex_client.py
+++ b/py/common/vertex_client.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/common/vertex_client_test.py
+++ b/py/common/vertex_client_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/data_models/__init__.py
+++ b/py/data_models/__init__.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/data_models/accounts.py
+++ b/py/data_models/accounts.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/data_models/accounts_test.py
+++ b/py/data_models/accounts_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/data_models/ad_groups.py
+++ b/py/data_models/ad_groups.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/data_models/ad_groups_test.py
+++ b/py/data_models/ad_groups_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/data_models/ads.py
+++ b/py/data_models/ads.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/data_models/ads_test.py
+++ b/py/data_models/ads_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/data_models/ads_test.py
+++ b/py/data_models/ads_test.py
@@ -54,6 +54,11 @@ _GOOGLE_ADS_RESPONSE = [
               'assetPerformanceLabel': 'PENDING',
               'policySummaryInfo':
               {'reviewStatus': 'REVIEWED',
+               'approvalStatus': 'APPROVED'}},
+             {'text': 'Sign up for {KeyWord:google ads}',
+              'assetPerformanceLabel': 'PENDING',
+              'policySummaryInfo':
+              {'reviewStatus': 'REVIEWED',
                'approvalStatus': 'APPROVED'}}],
             'descriptions':
             [{'text': 'Email thats intuitive, efficient, and useful',
@@ -62,6 +67,11 @@ _GOOGLE_ADS_RESPONSE = [
               {'reviewStatus': 'REVIEWED',
                'approvalStatus': 'APPROVED'}},
              {'text': '15 GB of storage, less spam, and mobile access',
+              'assetPerformanceLabel': 'PENDING',
+              'policySummaryInfo':
+              {'reviewStatus': 'REVIEWED',
+               'approvalStatus': 'APPROVED'}},
+             {'text': 'Open {Keyword:today} and {keyword: tomorrow}',
               'assetPerformanceLabel': 'PENDING',
               'policySummaryInfo':
               {'reviewStatus': 'REVIEWED',
@@ -97,6 +107,11 @@ _GOOGLE_ADS_RESPONSE = [
               'assetPerformanceLabel': 'PENDING',
               'policySummaryInfo':
               {'reviewStatus': 'REVIEWED',
+               'approvalStatus': 'APPROVED'}},
+             {'text': 'Powered by {KEYWord:"ai"}',
+              'assetPerformanceLabel': 'PENDING',
+              'policySummaryInfo':
+              {'reviewStatus': 'REVIEWED',
                'approvalStatus': 'APPROVED'}}],
             'descriptions':
             [{'text': 'Google Analytics',
@@ -105,6 +120,11 @@ _GOOGLE_ADS_RESPONSE = [
               {'reviewStatus': 'REVIEWED',
                'approvalStatus': 'APPROVED'}},
              {'text': 'Try Analytics today!',
+              'assetPerformanceLabel': 'PENDING',
+              'policySummaryInfo':
+              {'reviewStatus': 'REVIEWED',
+               'approvalStatus': 'APPROVED'}},
+             {'text': 'Try Analytics {Keyword:today}',
               'assetPerformanceLabel': 'PENDING',
               'policySummaryInfo':
               {'reviewStatus': 'REVIEWED',
@@ -139,8 +159,14 @@ _EXPECTED_DF = pd.DataFrame(
         'Original Headline 2': ['Online Email', 'Official Site'],
         'Headline 3': ['Sign in', 'High Quality Products'],
         'Original Headline 3': ['Sign in', 'High Quality Products'],
-        'Headline 4': ['', ''],
-        'Original Headline 4': ['', ''],
+        'Headline 4': [
+            'Sign up for {KeyWord:google ads}',
+            'Powered by {KEYWord:"ai"}',
+        ],
+        'Original Headline 4': [
+            'Sign up for {KeyWord:google ads}',
+            'Powered by {KEYWord:"ai"}',
+        ],
         'Headline 5': ['', ''],
         'Original Headline 5': ['', ''],
         'Headline 6': ['', ''],
@@ -179,8 +205,14 @@ _EXPECTED_DF = pd.DataFrame(
             '15 GB of storage, less spam, and mobile access',
             'Try Analytics today!',
         ],
-        'Description 3': ['', ''],
-        'Original Description 3': ['', ''],
+        'Description 3': [
+            'Open {Keyword:today} and {keyword: tomorrow}',
+            'Try Analytics {Keyword:today}',
+        ],
+        'Original Description 3': [
+            'Open {Keyword:today} and {keyword: tomorrow}',
+            'Try Analytics {Keyword:today}',
+        ],
         'Description 4': ['', ''],
         'Original Description 4': ['', ''],
         'Final URL': [
@@ -205,16 +237,21 @@ _EXPECTED_CSV_DATA = (
     ' 3,Description 4,Original Description 4,Final URL,Labels,Updates'
     ' applied\nAdd,Enter customer ID,Paused,Gmail Test Campaign,Ad group'
     ' 1,Responsive search ad,Email Login,Email Login,Online Email,Online'
-    ' Email,Sign in,Sign in,,,,,,,,,,,,,,,,,,,,,,,,,"Email thats intuitive,'
+    ' Email,Sign in,Sign in,Sign up for {KeyWord:google ads},Sign up for'
+    ' {KeyWord:google ads},,,,,,,,,,,,,,,,,,,,,,,"Email thats intuitive,'
     ' efficient, and useful","Email thats intuitive, efficient, and useful","15'
     ' GB of storage, less spam, and mobile access","15 GB of storage, less'
-    ' spam, and mobile access",,,,,https://mail.google.com/,Keyword'
-    ' Translator,[]\nAdd,Enter customer ID,Paused,Analytics Test Campaign,Ad'
-    ' group 1,Responsive search ad,Official Website,Official Website,Official'
-    ' Site,Official Site,High Quality Products,High Quality'
-    ' Products,,,,,,,,,,,,,,,,,,,,,,,,,Google Analytics,Google Analytics,Try'
-    ' Analytics today!,Try Analytics'
-    ' today!,,,,,http://analytics.google.com,Keyword Translator,[]\n'
+    ' spam, and mobile access",Open {Keyword:today} and {keyword:'
+    ' tomorrow},Open {Keyword:today} and {keyword:'
+    ' tomorrow},,,https://mail.google.com/,Keyword Translator,[]\nAdd,Enter'
+    ' customer ID,Paused,Analytics Test Campaign,Ad group 1,Responsive search'
+    ' ad,Official Website,Official Website,Official Site,Official Site,High'
+    ' Quality Products,High Quality Products,"Powered by'
+    ' {KEYWord:""ai""}","Powered by'
+    ' {KEYWord:""ai""}",,,,,,,,,,,,,,,,,,,,,,,Google Analytics,Google'
+    ' Analytics,Try Analytics today!,Try Analytics today!,Try Analytics'
+    ' {Keyword:today},Try Analytics'
+    ' {Keyword:today},,,http://analytics.google.com,Keyword Translator,[]\n'
 )
 
 _EXPECTED_DF_AFTER_UPDATE = pd.DataFrame(
@@ -231,8 +268,14 @@ _EXPECTED_DF_AFTER_UPDATE = pd.DataFrame(
         'Original Headline 2': ['Online Email', 'Official Site'],
         'Headline 3': ['Sign in', 'High Quality Products'],
         'Original Headline 3': ['Sign in', 'High Quality Products'],
-        'Headline 4': ['', ''],
-        'Original Headline 4': ['', ''],
+        'Headline 4': [
+            'Sign up for {KeyWord:google ads}',
+            'Powered by {KEYWord:"ai"}',
+        ],
+        'Original Headline 4': [
+            'Sign up for {KeyWord:google ads}',
+            'Powered by {KEYWord:"ai"}',
+        ],
         'Headline 5': ['', ''],
         'Original Headline 5': ['', ''],
         'Headline 6': ['', ''],
@@ -271,8 +314,14 @@ _EXPECTED_DF_AFTER_UPDATE = pd.DataFrame(
             '15 GB of storage, less spam, and mobile access',
             'Try Analytics today!',
         ],
-        'Description 3': ['', ''],
-        'Original Description 3': ['', ''],
+        'Description 3': [
+            'Open {Keyword:today} and {keyword: tomorrow}',
+            'Try Analytics {Keyword:today}',
+        ],
+        'Original Description 3': [
+            'Open {Keyword:today} and {keyword: tomorrow}',
+            'Try Analytics {Keyword:today}',
+        ],
         'Description 4': ['', ''],
         'Original Description 4': ['', ''],
         'Final URL': [
@@ -301,8 +350,14 @@ _EXPECTED_DF_AFTER_CAMPAIGN_AND_AD_GROUP_UPDATE = pd.DataFrame(
         'Original Headline 2': ['Online Email', 'Official Site'],
         'Headline 3': ['Sign in', 'High Quality Products'],
         'Original Headline 3': ['Sign in', 'High Quality Products'],
-        'Headline 4': ['', ''],
-        'Original Headline 4': ['', ''],
+        'Headline 4': [
+            'Sign up for {KeyWord:google ads}',
+            'Powered by {KEYWord:"ai"}',
+        ],
+        'Original Headline 4': [
+            'Sign up for {KeyWord:google ads}',
+            'Powered by {KEYWord:"ai"}',
+        ],
         'Headline 5': ['', ''],
         'Original Headline 5': ['', ''],
         'Headline 6': ['', ''],
@@ -341,8 +396,14 @@ _EXPECTED_DF_AFTER_CAMPAIGN_AND_AD_GROUP_UPDATE = pd.DataFrame(
             '15 GB of storage, less spam, and mobile access',
             'Try Analytics today!',
         ],
-        'Description 3': ['', ''],
-        'Original Description 3': ['', ''],
+        'Description 3': [
+            'Open {Keyword:today} and {keyword: tomorrow}',
+            'Try Analytics {Keyword:today}',
+        ],
+        'Original Description 3': [
+            'Open {Keyword:today} and {keyword: tomorrow}',
+            'Try Analytics {Keyword:today}',
+        ],
         'Description 4': ['', ''],
         'Original Description 4': ['', ''],
         'Final URL': [
@@ -433,8 +494,14 @@ _EXPECTED_DF_AFTER_TRANSLATION = pd.DataFrame(
         'Original Headline 2': ['Online Email', 'Official Site'],
         'Headline 3': ['anmelden', 'Produkte mit hoher Qualität'],
         'Original Headline 3': ['Sign in', 'High Quality Products'],
-        'Headline 4': ['', ''],
-        'Original Headline 4': ['', ''],
+        'Headline 4': [
+            'Melden Sie sich für {KeyWord:google ads} an',
+            'Unterstützt von {KEYWord:"ai"}',
+        ],
+        'Original Headline 4': [
+            'Sign up for {KeyWord:google ads}',
+            'Powered by {KEYWord:"ai"}',
+        ],
         'Headline 5': ['', ''],
         'Original Headline 5': ['', ''],
         'Headline 6': ['', ''],
@@ -473,8 +540,14 @@ _EXPECTED_DF_AFTER_TRANSLATION = pd.DataFrame(
             '15 GB of storage, less spam, and mobile access',
             'Try Analytics today!',
         ],
-        'Description 3': ['', ''],
-        'Original Description 3': ['', ''],
+        'Description 3': [
+            'Öffnen Sie {Keyword:heute} und {keyword:morgen}',
+            'Probieren Sie Analytics {Keyword:heute} aus',
+        ],
+        'Original Description 3': [
+            'Open {Keyword:today} and {keyword: tomorrow}',
+            'Try Analytics {Keyword:today}',
+        ],
         'Description 4': ['', ''],
         'Original Description 4': ['', ''],
         'Final URL': [
@@ -503,8 +576,14 @@ _EXPECTED_DF_AFTER_TRANSLATION_WITH_AD_GROUP_UPDATE = pd.DataFrame(
         'Original Headline 2': ['Online Email', 'Official Site'],
         'Headline 3': ['anmelden', 'Produkte mit hoher Qualität'],
         'Original Headline 3': ['Sign in', 'High Quality Products'],
-        'Headline 4': ['', ''],
-        'Original Headline 4': ['', ''],
+        'Headline 4': [
+            'Melden Sie sich für {KeyWord:google ads} an',
+            'Unterstützt von {KEYWord:"ai"}',
+        ],
+        'Original Headline 4': [
+            'Sign up for {KeyWord:google ads}',
+            'Powered by {KEYWord:"ai"}',
+        ],
         'Headline 5': ['', ''],
         'Original Headline 5': ['', ''],
         'Headline 6': ['', ''],
@@ -543,8 +622,14 @@ _EXPECTED_DF_AFTER_TRANSLATION_WITH_AD_GROUP_UPDATE = pd.DataFrame(
             '15 GB of storage, less spam, and mobile access',
             'Try Analytics today!',
         ],
-        'Description 3': ['', ''],
-        'Original Description 3': ['', ''],
+        'Description 3': [
+            'Öffnen Sie {Keyword:heute} und {keyword:morgen}',
+            'Probieren Sie Analytics {Keyword:heute} aus',
+        ],
+        'Original Description 3': [
+            'Open {Keyword:today} and {keyword: tomorrow}',
+            'Try Analytics {Keyword:today}',
+        ],
         'Description 4': ['', ''],
         'Original Description 4': ['', ''],
         'Final URL': [
@@ -686,52 +771,83 @@ class AdsTest(parameterized.TestCase):
     actual_df = ads.df()
 
     pd.testing.assert_frame_equal(
-        actual_df, expected_df, check_index_type=False)
+        actual_df, expected_df, check_index_type=False
+    )
 
   def test_get_translation_frame(self):
-    expected_df = pd.DataFrame(
-        {
-            'source_term': ['Email Login',
-                            'Online Email',
-                            'Sign in',
-                            'Email thats intuitive, efficient, and useful',
-                            '15 GB of storage, less spam, and mobile access',
-                            'Official Website',
-                            'Official Site',
-                            'High Quality Products',
-                            'Google Analytics',
-                            'Try Analytics today!'],
-            'target_terms': [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}],
-            'dataframe_locations': [
-                [(0, 'Headline 1')],
-                [(0, 'Headline 2')],
-                [(0, 'Headline 3')],
-                [(0, 'Description 1')],
-                [(0, 'Description 2')],
-                [(1, 'Headline 1')],
-                [(1, 'Headline 2')],
-                [(1, 'Headline 3')],
-                [(1, 'Description 1')],
-                [(1, 'Description 2')]],
-            'char_limit': [
-                30,
-                30,
-                30,
-                90,
-                90,
-                30,
-                30,
-                30,
-                90,
-                90,
-            ],
-            })
+    expected_df = pd.DataFrame({
+        'source_term': [
+            'Email Login',
+            'Online Email',
+            'Sign in',
+            'Sign up for {0:google ads}',
+            'Email thats intuitive, efficient, and useful',
+            '15 GB of storage, less spam, and mobile access',
+            'Open {0:today} and {1: tomorrow}',
+            'Official Website',
+            'Official Site',
+            'High Quality Products',
+            'Powered by {0:"ai"}',
+            'Google Analytics',
+            'Try Analytics today!',
+            'Try Analytics {0:today}',
+        ],
+        'target_terms': [
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+        ],
+        'dataframe_locations': [
+            [(0, 'Headline 1')],
+            [(0, 'Headline 2')],
+            [(0, 'Headline 3')],
+            [(0, 'Headline 4')],
+            [(0, 'Description 1')],
+            [(0, 'Description 2')],
+            [(0, 'Description 3')],
+            [(1, 'Headline 1')],
+            [(1, 'Headline 2')],
+            [(1, 'Headline 3')],
+            [(1, 'Headline 4')],
+            [(1, 'Description 1')],
+            [(1, 'Description 2')],
+            [(1, 'Description 3')],
+        ],
+        'char_limit': [
+            30,
+            30,
+            30,
+            30,
+            90,
+            90,
+            90,
+            30,
+            30,
+            30,
+            30,
+            90,
+            90,
+            90,
+        ],
+    })
 
     ads = ads_lib.Ads(_GOOGLE_ADS_RESPONSE)
     actual_df = ads.get_translation_frame().df()
 
     pd.testing.assert_frame_equal(
-        actual_df, expected_df, check_index_type=False)
+        actual_df, expected_df, check_index_type=False
+    )
 
   @parameterized.named_parameters(
       {
@@ -757,13 +873,17 @@ class AdsTest(parameterized.TestCase):
             'E-Mail-Login',
             'Online-E-Mail',
             'anmelden',
+            'Melden Sie sich für {0:google ads} an',
             'E-Mail, die intuitiv, effizient und nützlich ist',
             '15 GB Speicherplatz, weniger Spam und mobiler Zugriff',
+            'Öffnen Sie {0:heute} und {1:morgen}',
             'Offizielle Website',
             'Offizielle Seite',
             'Produkte mit hoher Qualität',
+            'Unterstützt von {0:"ai"}',
             'Google Analytics',
             'Probieren Sie Analytics noch heute aus!',
+            'Probieren Sie Analytics {0:heute} aus',
             ])
 
     ads.apply_translations(
@@ -778,7 +898,7 @@ class AdsTest(parameterized.TestCase):
   def test_char_count(self):
     ads = ads_lib.Ads(_GOOGLE_ADS_RESPONSE)
 
-    expected_char_count = 183
+    expected_char_count = 301
 
     actual_char_count = ads.char_count()
 

--- a/py/data_models/campaigns.py
+++ b/py/data_models/campaigns.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/data_models/campaigns_test.py
+++ b/py/data_models/campaigns_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/data_models/extensions.py
+++ b/py/data_models/extensions.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/data_models/extensions_test.py
+++ b/py/data_models/extensions_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/data_models/google_ads_objects.py
+++ b/py/data_models/google_ads_objects.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/data_models/google_ads_objects_test.py
+++ b/py/data_models/google_ads_objects_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/data_models/keywords.py
+++ b/py/data_models/keywords.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/data_models/keywords_test.py
+++ b/py/data_models/keywords_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/data_models/settings.py
+++ b/py/data_models/settings.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/data_models/translation_frame.py
+++ b/py/data_models/translation_frame.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/data_models/translation_frame_test.py
+++ b/py/data_models/translation_frame_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/data_models/translation_metadata.py
+++ b/py/data_models/translation_metadata.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/execution_runner.py
+++ b/py/execution_runner.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/execution_runner_test.py
+++ b/py/execution_runner_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/main.py
+++ b/py/main.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/workers/__init__.py
+++ b/py/workers/__init__.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/workers/base_worker.py
+++ b/py/workers/base_worker.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/workers/translation_worker.py
+++ b/py/workers/translation_worker.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/workers/translation_worker_test.py
+++ b/py/workers/translation_worker_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/py/workers/translation_worker_test.py
+++ b/py/workers/translation_worker_test.py
@@ -76,6 +76,29 @@ _KEYWORDS_GOOGLE_ADS_API_RESPONSE = [[{
                 'resourceName': 'customers/123/keywordViews/789~1314'
             },
         },
+        {
+            'customer': {'resourceName': 'customers/123', 'id': '123'},
+            'campaign': {
+                'resourceName': 'customers/123/campaigns/012',
+                'advertisingChannelType': 'SEARCH',
+                'biddingStrategyType': 'TARGET_SPEND',
+                'name': 'Gmail Test Campaign',
+            },
+            'adGroup': {
+                'resourceName': 'customers/123/adGroups/789',
+                'name': 'Ad group 1',
+            },
+            'adGroupCriterion': {
+                'resourceName': 'customers/123/adGroupCriteria/789~1516',
+                'keyword': {
+                    'matchType': 'BROAD',
+                    'text': 'Open {Keyword:today} and {keyword: tomorrow}',
+                },
+            },
+            'keywordView': {
+                'resourceName': 'customers/123/keywordViews/789~1516'
+            },
+        },
     ],
     'fieldMask': 'fake_field_mask',
     'requestId': 'fake_req_id',
@@ -122,6 +145,14 @@ _ADS_DATA_GOOGLE_ADS_API_RESPONSE = [[{
                                     'approvalStatus': 'APPROVED',
                                 },
                             },
+                            {
+                                'text': 'Sign up for {KeyWord:google ads}',
+                                'assetPerformanceLabel': 'PENDING',
+                                'policySummaryInfo': {
+                                    'reviewStatus': 'REVIEWED',
+                                    'approvalStatus': 'APPROVED',
+                                },
+                            },
                         ],
                         'descriptions': [
                             {
@@ -139,6 +170,17 @@ _ADS_DATA_GOOGLE_ADS_API_RESPONSE = [[{
                                 'text': (
                                     '15 GB of storage, less spam, and mobile'
                                     ' access'
+                                ),
+                                'assetPerformanceLabel': 'PENDING',
+                                'policySummaryInfo': {
+                                    'reviewStatus': 'REVIEWED',
+                                    'approvalStatus': 'APPROVED',
+                                },
+                            },
+                            {
+                                'text': (
+                                    'Open {Keyword:today} and {keyword:'
+                                    ' tomorrow}'
                                 ),
                                 'assetPerformanceLabel': 'PENDING',
                                 'policySummaryInfo': {
@@ -192,6 +234,14 @@ _ADS_DATA_GOOGLE_ADS_API_RESPONSE = [[{
                                     'approvalStatus': 'APPROVED',
                                 },
                             },
+                            {
+                                'text': 'Powered by {KEYWord:"ai"}',
+                                'assetPerformanceLabel': 'PENDING',
+                                'policySummaryInfo': {
+                                    'reviewStatus': 'REVIEWED',
+                                    'approvalStatus': 'APPROVED',
+                                },
+                            },
                         ],
                         'descriptions': [
                             {
@@ -204,6 +254,14 @@ _ADS_DATA_GOOGLE_ADS_API_RESPONSE = [[{
                             },
                             {
                                 'text': 'Try Analytics today!',
+                                'assetPerformanceLabel': 'PENDING',
+                                'policySummaryInfo': {
+                                    'reviewStatus': 'REVIEWED',
+                                    'approvalStatus': 'APPROVED',
+                                },
+                            },
+                            {
+                                'text': 'Try Analytics {Keyword:today}',
                                 'assetPerformanceLabel': 'PENDING',
                                 'policySummaryInfo': {
                                     'reviewStatus': 'REVIEWED',
@@ -347,6 +405,14 @@ _AD_GROUPS_GOOGLE_ADS_RESPONSE = [
                                         'approvalStatus': 'APPROVED',
                                     },
                                 },
+                                {
+                                    'text': 'Sign up for {KeyWord:google ads}',
+                                    'assetPerformanceLabels': 'PENDING',
+                                    'policySummaryInfo': {
+                                        'reviewStatus': 'REVIEWED',
+                                        'approvalStatus': 'APPROVED',
+                                    },
+                                },
                             ],
                             'descriptions': [
                                 {
@@ -364,6 +430,17 @@ _AD_GROUPS_GOOGLE_ADS_RESPONSE = [
                                     'text': (
                                         '15 GB of storage, less spam, and'
                                         ' mobile access'
+                                    ),
+                                    'assetPerformanceLabels': 'PENDING',
+                                    'policySummaryInfo': {
+                                        'reviewStatus': 'REVIEWED',
+                                        'approvalStatus': 'APPROVED',
+                                    },
+                                },
+                                {
+                                    'text': (
+                                        'Open {Keyword:today} and {keyword:'
+                                        ' tomorrow}'
                                     ),
                                     'assetPerformanceLabels': 'PENDING',
                                     'policySummaryInfo': {
@@ -417,6 +494,14 @@ _AD_GROUPS_GOOGLE_ADS_RESPONSE = [
                                         'approvalStatus': 'APPROVED',
                                     },
                                 },
+                                {
+                                    'text': 'Powered by {KEYWord:"ai"}',
+                                    'assetPerformanceLabels': 'PENDING',
+                                    'policySummaryInfo': {
+                                        'reviewStatus': 'REVIEWED',
+                                        'approvalStatus': 'APPROVED',
+                                    },
+                                },
                             ],
                             'descriptions': [
                                 {
@@ -429,6 +514,14 @@ _AD_GROUPS_GOOGLE_ADS_RESPONSE = [
                                 },
                                 {
                                     'text': 'Try Analytics today!',
+                                    'assetPerformanceLabels': 'PENDING',
+                                    'policySummaryInfo': {
+                                        'reviewStatus': 'REVIEWED',
+                                        'approvalStatus': 'APPROVED',
+                                    },
+                                },
+                                {
+                                    'text': 'Try Analytics {Keyword:today}',
                                     'assetPerformanceLabels': 'PENDING',
                                     'policySummaryInfo': {
                                         'reviewStatus': 'REVIEWED',
@@ -913,16 +1006,36 @@ _EXPECTED_EXTENSIONS_DF_WHEN_TRANSLATION_SKIPPED = pd.DataFrame({
 
 _EXPECTED_KEYWORDS_DF = pd.DataFrame(
     {
-        'Action': ['Add', 'Add'],
-        'Customer ID': ['Enter customer ID', 'Enter customer ID'],
-        'Campaign': ['Gmail Test Campaign (es)', 'Gmail Test Campaign (es)'],
-        'Ad group': ['Ad group 1 (es)', 'Ad group 1 (es)'],
-        'Keyword': ['correo electrónico', 'rápido'],
-        'Original Keyword': ['e mail', 'fast'],
-        'Match Type': ['BROAD', 'BROAD'],
-        'Keyword status': ['Paused', 'Paused'],
-        'Labels': ['Keyword Translator', 'Keyword Translator'],
-        'Updates applied': [[], []],
+        'Action': ['Add', 'Add', 'Add'],
+        'Customer ID': [
+            'Enter customer ID',
+            'Enter customer ID',
+            'Enter customer ID',
+        ],
+        'Campaign': [
+            'Gmail Test Campaign (es)',
+            'Gmail Test Campaign (es)',
+            'Gmail Test Campaign (es)',
+        ],
+        'Ad group': ['Ad group 1 (es)', 'Ad group 1 (es)', 'Ad group 1 (es)'],
+        'Keyword': [
+            'correo electrónico',
+            'rápido',
+            'Abra {palabra clave:hoy} y {palabra clave: mañana}',
+        ],
+        'Original Keyword': [
+            'e mail',
+            'fast',
+            'Open {Keyword:today} and {keyword: tomorrow}',
+        ],
+        'Match Type': ['BROAD', 'BROAD', 'BROAD'],
+        'Keyword status': ['Paused', 'Paused', 'Paused'],
+        'Labels': [
+            'Keyword Translator',
+            'Keyword Translator',
+            'Keyword Translator',
+        ],
+        'Updates applied': [[], [], []],
     },
 )
 
@@ -946,8 +1059,14 @@ _EXPECTED_ADS_DF = pd.DataFrame(
         'Original Headline 2': ['Online Email', 'Official Site'],
         'Headline 3': ['Iniciar sesión', 'Productos de alta calidad'],
         'Original Headline 3': ['Sign in', 'High Quality Products'],
-        'Headline 4': ['', ''],
-        'Original Headline 4': ['', ''],
+        'Headline 4': [
+            'Regístrate en {KeyWord:google ads}',
+            'Desarrollado por {KEYWord:"ai"}',
+        ],
+        'Original Headline 4': [
+            'Sign up for {KeyWord:google ads}',
+            'Powered by {KEYWord:"ai"}',
+        ],
         'Headline 5': ['', ''],
         'Original Headline 5': ['', ''],
         'Headline 6': ['', ''],
@@ -986,8 +1105,14 @@ _EXPECTED_ADS_DF = pd.DataFrame(
             '15 GB of storage, less spam, and mobile access',
             'Try Analytics today!',
         ],
-        'Description 3': ['', ''],
-        'Original Description 3': ['', ''],
+        'Description 3': [
+            'Abra {Keyword:hoy} y {keyword: mañana}',
+            'Pruebe Analytics {Keyword:hoy}',
+        ],
+        'Original Description 3': [
+            'Open {Keyword:today} and {keyword: tomorrow}',
+            'Try Analytics {Keyword:today}',
+        ],
         'Description 4': ['', ''],
         'Original Description 4': ['', ''],
         'Final URL': [
@@ -1016,8 +1141,14 @@ _EXPECTED_ADS_DF_WHEN_TRANSLATION_SKIPPED = pd.DataFrame(
         'Original Headline 2': ['Online Email', 'Official Site'],
         'Headline 3': ['Sign in', 'High Quality Products'],
         'Original Headline 3': ['Sign in', 'High Quality Products'],
-        'Headline 4': ['', ''],
-        'Original Headline 4': ['', ''],
+        'Headline 4': [
+            'Sign up for {KeyWord:google ads}',
+            'Powered by {KEYWord:"ai"}',
+        ],
+        'Original Headline 4': [
+            'Sign up for {KeyWord:google ads}',
+            'Powered by {KEYWord:"ai"}',
+        ],
         'Headline 5': ['', ''],
         'Original Headline 5': ['', ''],
         'Headline 6': ['', ''],
@@ -1056,8 +1187,14 @@ _EXPECTED_ADS_DF_WHEN_TRANSLATION_SKIPPED = pd.DataFrame(
             '15 GB of storage, less spam, and mobile access',
             'Try Analytics today!',
         ],
-        'Description 3': ['', ''],
-        'Original Description 3': ['', ''],
+        'Description 3': [
+            'Open {Keyword:today} and {keyword: tomorrow}',
+            'Try Analytics {Keyword:today}',
+        ],
+        'Original Description 3': [
+            'Open {Keyword:today} and {keyword: tomorrow}',
+            'Try Analytics {Keyword:today}',
+        ],
         'Description 4': ['', ''],
         'Original Description 4': ['', ''],
         'Final URL': [
@@ -1153,6 +1290,11 @@ class TranslationWorkerTest(absltest.TestCase):
             'translations': [
                 {'translatedText': 'correo electrónico'},
                 {'translatedText': 'rápido'},
+                {
+                    'translatedText': (
+                        'Abra {palabra clave:hoy} y {palabra clave: mañana}'
+                    )
+                },
             ]
         },
         {
@@ -1160,13 +1302,17 @@ class TranslationWorkerTest(absltest.TestCase):
                 {'translatedText': 'Inicio de sesión de correo electrónico'},
                 {'translatedText': 'Correo electrónico en línea'},
                 {'translatedText': 'Iniciar sesión'},
+                {'translatedText': 'Regístrate en {KeyWord:google ads}'},
                 {'translatedText': 'Correo electrónico intuitivo y útil'},
                 {'translatedText': '15 GB de almacenamiento y acceso móvil'},
+                {'translatedText': 'Abra {Keyword:hoy} y {keyword: mañana}'},
                 {'translatedText': 'Página web oficial'},
                 {'translatedText': 'Sitio oficial'},
                 {'translatedText': 'Productos de alta calidad'},
+                {'translatedText': 'Desarrollado por {KEYWord:"ai"}'},
                 {'translatedText': 'Google analitico'},
                 {'translatedText': '¡Pruebe Analytics hoy!'},
+                {'translatedText': 'Pruebe Analytics {Keyword:hoy}'},
             ]
         },
         {
@@ -1215,7 +1361,7 @@ class TranslationWorkerTest(absltest.TestCase):
         settings=settings, google_ads_objects=google_ads_objects)
 
     # Asserts result
-    self.assertEqual(2, result.keywords_modified)
+    self.assertEqual(3, result.keywords_modified)
     self.assertEqual(worker_result.Status.SUCCESS, result.status)
 
     # Asserts keywords translated
@@ -1314,10 +1460,19 @@ class TranslationWorkerTest(absltest.TestCase):
     )
 
     mock_send_api_request.side_effect = [
-        {'translations': [
-            {'translatedText': 'correo electrónico'},
-            {'translatedText': 'rápido'}]},
-        requests.exceptions.HTTPError()]
+        {
+            'translations': [
+                {'translatedText': 'correo electrónico'},
+                {'translatedText': 'rápido'},
+                {
+                    'translatedText': (
+                        'Abra {palabra clave:hoy} y {palabra clave: mañana}'
+                    )
+                },
+            ]
+        },
+        requests.exceptions.HTTPError(),
+    ]
 
     mock_refresh_access_token.return_value = 'fake_access_token'
 
@@ -1380,10 +1535,17 @@ class TranslationWorkerTest(absltest.TestCase):
         )
     )
 
-    mock_send_api_request.side_effect = [
-        {'translations': [
+    mock_send_api_request.side_effect = [{
+        'translations': [
             {'translatedText': 'correo electrónico'},
-            {'translatedText': 'rápido'}]}]
+            {'translatedText': 'rápido'},
+            {
+                'translatedText': (
+                    'Abra {palabra clave: hoy} y {palabra clave: mañana}'
+                )
+            },
+        ]
+    }]
 
     mock_refresh_access_token.return_value = 'fake_access_token'
 

--- a/py/workers/worker_result.py
+++ b/py/workers/worker_result.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/setup/utils/oauth_flow.py
+++ b/setup/utils/oauth_flow.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/setup/utils/oauth_flow_test.py
+++ b/setup/utils/oauth_flow_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/system_tests/backend_test.py
+++ b/system_tests/backend_test.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/system_tests/cloudbuild.yaml
+++ b/system_tests/cloudbuild.yaml
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/system_tests/conftest.py
+++ b/system_tests/conftest.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/system_tests/requirements.txt
+++ b/system_tests/requirements.txt
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/terraform/apis.tf
+++ b/terraform/apis.tf
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/terraform/certificates.tf
+++ b/terraform/certificates.tf
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/terraform/iam_policies.tf
+++ b/terraform/iam_policies.tf
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/terraform/identity_aware_proxy.tf
+++ b/terraform/identity_aware_proxy.tf
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/terraform/output_values.tf
+++ b/terraform/output_values.tf
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/.dockerignore
+++ b/ui/.dockerignore
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/py/__init__.py
+++ b/ui/py/__init__.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/py/main.py
+++ b/ui/py/main.py
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/py/requirements.txt
+++ b/ui/py/requirements.txt
@@ -1,10 +1,10 @@
-# Copyright 2023 Google LLC.
+# Copyright 2024 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/accounts/accounts.component.html
+++ b/ui/src/app/accounts/accounts.component.html
@@ -1,11 +1,11 @@
 <!--
- Copyright 2023 Google LLC.
+ Copyright 2024 Google LLC.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/accounts/accounts.component.scss
+++ b/ui/src/app/accounts/accounts.component.scss
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/accounts/accounts.component.spec.ts
+++ b/ui/src/app/accounts/accounts.component.spec.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/accounts/accounts.component.ts
+++ b/ui/src/app/accounts/accounts.component.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -1,11 +1,11 @@
 <!--
- Copyright 2023 Google LLC.
+ Copyright 2024 Google LLC.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/app.component.scss
+++ b/ui/src/app/app.component.scss
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/app.component.spec.ts
+++ b/ui/src/app/app.component.spec.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/campaigns/campaigns.component.html
+++ b/ui/src/app/campaigns/campaigns.component.html
@@ -1,11 +1,11 @@
 <!--
- Copyright 2023 Google LLC.
+ Copyright 2024 Google LLC.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/campaigns/campaigns.component.scss
+++ b/ui/src/app/campaigns/campaigns.component.scss
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/campaigns/campaigns.component.spec.ts
+++ b/ui/src/app/campaigns/campaigns.component.spec.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/campaigns/campaigns.component.ts
+++ b/ui/src/app/campaigns/campaigns.component.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/content/content.component.html
+++ b/ui/src/app/content/content.component.html
@@ -1,11 +1,11 @@
 <!--
- Copyright 2023 Google LLC.
+ Copyright 2024 Google LLC.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/content/content.component.scss
+++ b/ui/src/app/content/content.component.scss
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/content/content.component.spec.ts
+++ b/ui/src/app/content/content.component.spec.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/content/content.component.ts
+++ b/ui/src/app/content/content.component.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/dialog/dialog.component.html
+++ b/ui/src/app/dialog/dialog.component.html
@@ -1,11 +1,11 @@
 <!--
- Copyright 2023 Google LLC.
+ Copyright 2024 Google LLC.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/dialog/dialog.component.scss
+++ b/ui/src/app/dialog/dialog.component.scss
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/dialog/dialog.component.spec.ts
+++ b/ui/src/app/dialog/dialog.component.spec.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/dialog/dialog.component.ts
+++ b/ui/src/app/dialog/dialog.component.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/models/enums.ts
+++ b/ui/src/app/models/enums.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/models/interfaces.ts
+++ b/ui/src/app/models/interfaces.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/models/types.ts
+++ b/ui/src/app/models/types.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/multi-select/multi-select.component.html
+++ b/ui/src/app/multi-select/multi-select.component.html
@@ -1,11 +1,11 @@
 <!--
- Copyright 2023 Google LLC.
+ Copyright 2024 Google LLC.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/multi-select/multi-select.component.scss
+++ b/ui/src/app/multi-select/multi-select.component.scss
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/multi-select/multi-select.component.spec.ts
+++ b/ui/src/app/multi-select/multi-select.component.spec.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/multi-select/multi-select.component.ts
+++ b/ui/src/app/multi-select/multi-select.component.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/services/google-ads.service.spec.ts
+++ b/ui/src/app/services/google-ads.service.spec.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/services/google-ads.service.ts
+++ b/ui/src/app/services/google-ads.service.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/services/run.service.spec.ts
+++ b/ui/src/app/services/run.service.spec.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/services/run.service.ts
+++ b/ui/src/app/services/run.service.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/services/services_module.ts
+++ b/ui/src/app/services/services_module.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/services/translation.service.spec.ts
+++ b/ui/src/app/services/translation.service.spec.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/services/translation.service.ts
+++ b/ui/src/app/services/translation.service.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/shared/tokens.ts
+++ b/ui/src/app/shared/tokens.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/shared/utils.ts
+++ b/ui/src/app/shared/utils.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/single-select/single-select.component.html
+++ b/ui/src/app/single-select/single-select.component.html
@@ -1,11 +1,11 @@
 <!--
- Copyright 2023 Google LLC.
+ Copyright 2024 Google LLC.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/single-select/single-select.component.scss
+++ b/ui/src/app/single-select/single-select.component.scss
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/single-select/single-select.component.spec.ts
+++ b/ui/src/app/single-select/single-select.component.spec.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/single-select/single-select.component.ts
+++ b/ui/src/app/single-select/single-select.component.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/snackbar/snackbar.component.html
+++ b/ui/src/app/snackbar/snackbar.component.html
@@ -1,11 +1,11 @@
 <!--
- Copyright 2023 Google LLC.
+ Copyright 2024 Google LLC.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/snackbar/snackbar.component.scss
+++ b/ui/src/app/snackbar/snackbar.component.scss
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/snackbar/snackbar.component.spec.ts
+++ b/ui/src/app/snackbar/snackbar.component.spec.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/snackbar/snackbar.component.ts
+++ b/ui/src/app/snackbar/snackbar.component.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/translation/translation.component.html
+++ b/ui/src/app/translation/translation.component.html
@@ -1,11 +1,11 @@
 <!--
- Copyright 2023 Google LLC.
+ Copyright 2024 Google LLC.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/translation/translation.component.html
+++ b/ui/src/app/translation/translation.component.html
@@ -87,8 +87,13 @@
         [ngModelOptions]="{standalone: true}">
       Shorten overflowing translations with GenAI (experimental)
     </mat-slide-toggle>
+    <!-- TODO(): Shorten text that include keyword insertion tags
+    for ads translations. -->
     <p class="note">If enabled, will use generative AI to ensure translations
       are below the Google Ads character limit for ad head and description
-      lines.<br>May result in lower quality translations.</p>
+      lines.<br>May result in lower quality translations. Note that headlines
+      and descriptions with
+      <a href="https://support.google.com/google-ads/answer/2454041"
+      target="_blank">keyword insertions</a> will not get shortened.</p>
   </div>
 </form>

--- a/ui/src/app/translation/translation.component.scss
+++ b/ui/src/app/translation/translation.component.scss
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/translation/translation.component.spec.ts
+++ b/ui/src/app/translation/translation.component.spec.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/app/translation/translation.component.ts
+++ b/ui/src/app/translation/translation.component.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -1,11 +1,11 @@
 <!--
- Copyright 2023 Google LLC.
+ Copyright 2024 Google LLC.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+     https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -1,12 +1,12 @@
 /**
  * @license
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Keyword insertion tag regular expression tested and verified against allowed tag pattern in the Google Ads UI. E.g. {"Keyword"}: Hello World} does not create a keyword insertion whereas {Keyword}: Hello World} or {Keyword}: "Hello World"} does.

Replacement key in the tag is a number due to other approaches being inconsistent when translating:
- I like {"Keyword": Apple} -> Me gusta {"Palabra clave": Apple}
- I like {"Keyword": Apple} -> Ich mag {"Keyword": Apple}
- I like <span translate="no">Keyword</span>: Apple -> Me gusta <span Translate="no">Palabra clave</span>: Apple